### PR TITLE
feat: add support for unsetting config values via override fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,17 +142,17 @@ By default, it will set 3 settings:
 It works by monkeypatching the `GIT_CONFIG_GLOBAL` environment variable.
 So, if you rely on this in a context where `os.environ` is ignored, you should patch it yourself using this fixture.
 
-#### `default_git_user_name -> str`
+#### `default_git_user_name -> str | UnsetType`
 
 Provide the initial `user.name` setting. By default `pytest_gitconfig.DEFAULT_GIT_USER_NAME`.
 Override to provide a different initial value.
 
-#### `default_git_user_email -> str`
+#### `default_git_user_email -> str | UnsetType`
 
 Provide the initial `user.email` setting. By default `pytest_gitconfig.DEFAULT_GIT_USER_EMAIL`.
 Override to provide a different initial value.
 
-#### `default_git_init_default_branch -> str`
+#### `default_git_init_default_branch -> str | UnsetType`
 
 Provide the initial `init.defaultBranch` setting. By default `pytest_gitconfig.DEFAULT_GIT_BRANCH` (`main`).
 Override to provide a different initial value.
@@ -172,7 +172,7 @@ An object materializing a given `gitconfig` file.
 Write some `gitconfig` values.
 It accepts a `dict` of parsed data sections as dict or dotted-key-values.
 
-#### `get(self, key: str, default: Any = _UNSET)`
+#### `get(self, key: str, default: Any = UNSET)`
 
 Get a setting given its dotted key. Get a 2nd default value. Raise `KeyError` if config does not exists and `default` is not provided
 

--- a/tests/test_override_defaults_unset.py
+++ b/tests/test_override_defaults_unset.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pytest_gitconfig import (
+    DEFAULT_GIT_BRANCH,
+    DEFAULT_GIT_USER_EMAIL,
+    DEFAULT_GIT_USER_NAME,
+    GitConfig,
+)
+from pytest_gitconfig.plugin import UNSET, UnsetType
+
+pytestmark = pytest.mark.mypy_testing
+
+
+@pytest.fixture
+def git_user_name() -> str | UnsetType:
+    return UNSET
+
+
+@pytest.fixture
+def git_user_email() -> str | UnsetType:
+    return UNSET
+
+
+@pytest.fixture
+def git_init_default_branch() -> str | UnsetType:
+    return UNSET
+
+
+def test_gitconfig_fixture_override_defaults(default_gitconfig: GitConfig):
+    assert default_gitconfig.get("user.name") == DEFAULT_GIT_USER_NAME
+    assert default_gitconfig.get("user.email") == DEFAULT_GIT_USER_EMAIL
+    assert default_gitconfig.get("init.defaultBranch") == DEFAULT_GIT_BRANCH
+    assert "GIT_WHATEVER" not in os.environ
+
+
+def test_gitconfig_fixture_override(gitconfig: GitConfig):
+    with pytest.raises(KeyError):
+        gitconfig.get("user.name")
+    with pytest.raises(KeyError):
+        gitconfig.get("user.email")
+    with pytest.raises(KeyError):
+        gitconfig.get("init.defaultBranch")
+    assert "GIT_WHATEVER" not in os.environ


### PR DESCRIPTION
I've added support unsetting Git config values via override fixtures. For instance:

```python
import pytest
from pytest_gitconfig.plugin import UNSET, UnsetType

@pytest.fixture(scope="session")
def default_git_user_name() -> str | UnsetType:
    return UNSET

# or

@pytest.fixture(scope="session")
def git_user_name() -> str | None | UnsetType:
    return UNSET
```

The need for unsetting such Git settings came up in https://github.com/copier-org/copier/pull/1716, as we need to run Copier's test suite without the Git user identity to avoid implicit assumptions about its existence. Since `pytest-gitconfig` sets a default user identity, we need to [unset it via override fixtures](https://github.com/copier-org/copier/blob/0258635da712f1c126db72051b46e62d2695c5ca/tests/conftest.py#L41-L50) (using `DELETE` and return type `Any` to make it work, giving rise to this PR for officially supporting this use case).

I was first considering to use the `DELETE` sentinel, but I think it's more intuitive to use a declarative sentinel (`UNSET`) rather than an imperative one (`DELETE`). As of this PR, `DELETE` and `UNSET` are redundant, but I kept `DELETE` for backwards compatibility.

Note that I only added a new test file for testing `git_*` override fixtures but not a second one for testing `default_git_*` override fixtures because the latter requires override fixtures with `scope="session"` which collide with those in `conftest.py` and has side effects for the other test files. And I can't use a lower scope for the `default_git_*` override fixtures because they are used by the ["session"-scoped fixture `default_gitconfig`](https://github.com/noirbizarre/pytest-gitconfig/blob/2e4871929cc93da90a42ca8aa10b400128cd2155/src/pytest_gitconfig/plugin.py#L122-L129), requiring them to have `scope="session"` as well.

WDYT, @noirbizarre?