### PR TITLE
ci(release): use PyPA action to release and benefit from digital attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Publish on PyPI
-        run: pdm publish --no-build
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Publish summary
         run: |


### PR DESCRIPTION
Use PyPA action to release and benefit from digital attestations.